### PR TITLE
[AIRFLOW-2840] - add update connections cli option

### DIFF
--- a/airflow/api/client/api_client.py
+++ b/airflow/api/client/api_client.py
@@ -69,3 +69,67 @@ class Client(object):
         :param name: pool name
         """
         raise NotImplementedError()
+
+    def add_connection(self, conn_id,
+                       conn_uri=None,
+                       conn_type=None,
+                       conn_host=None,
+                       conn_login=None,
+                       conn_password=None,
+                       conn_schema=None,
+                       conn_port=None,
+                       conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The new Connection
+        """
+        raise NotImplementedError()
+
+    def delete_connection(self, conn_id, delete_all=False):
+        """
+
+        :param conn_id:
+        :param delete_all:
+        :return: the conn_id(s) of the Connection(s) that were removed
+        """
+        raise NotImplementedError()
+
+    def list_connections(self):
+        """
+
+        :return: All Connections
+        """
+        raise NotImplementedError()
+
+    def update_connection(self, conn_id,
+                          conn_uri=None,
+                          conn_type=None,
+                          conn_host=None,
+                          conn_login=None,
+                          conn_password=None,
+                          conn_schema=None,
+                          conn_port=None,
+                          conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The updated Connection
+        """
+        raise NotImplementedError()

--- a/airflow/api/client/json_client.py
+++ b/airflow/api/client/json_client.py
@@ -89,3 +89,84 @@ class Client(api_client.Client):
         url = urljoin(self._api_base_url, endpoint)
         pool = self._request(url, method='DELETE')
         return pool['pool'], pool['slots'], pool['description']
+
+    def add_connection(self, conn_id,
+                       conn_uri=None,
+                       conn_type=None,
+                       conn_host=None,
+                       conn_login=None,
+                       conn_password=None,
+                       conn_schema=None,
+                       conn_port=None,
+                       conn_extra=None):
+        endpoint = '/api/experimental/connections/'
+        url = urljoin(self._api_base_url, endpoint)
+        conn = self._request(url, method='POST', json={
+            'conn_id': conn_id,
+            'conn_uri': conn_uri,
+            'conn_type': conn_type,
+            'conn_host': conn_host,
+            'conn_login': conn_login,
+            'conn_password': conn_password,
+            'conn_schema': conn_schema,
+            'conn_port': conn_port,
+            'conn_extra': conn_extra})
+        return conn.to_json()
+
+    def delete_connection(self, conn_id, delete_all=False):
+        """
+
+        :param conn_id:
+        :param delete_all:
+        :return: the conn_id(s) of the Connection(s) that were removed
+        """
+        endpoint = '/api/experimental/connections/{}'.format(conn_id)
+        url = urljoin(self._api_base_url, endpoint)
+        conn_id = self._request(url, method='DELETE', json={'delete_all': delete_all})
+        return conn_id
+
+    def list_connections(self):
+        """
+
+        :return: All Connections
+        """
+        endpoint = '/api/experimental/connections'
+        url = urljoin(self._api_base_url, endpoint)
+        conns = self._request(url)
+        return [conn.to_json() for conn in conns]
+
+    def update_connection(self, conn_id,
+                          conn_uri=None,
+                          conn_type=None,
+                          conn_host=None,
+                          conn_login=None,
+                          conn_password=None,
+                          conn_schema=None,
+                          conn_port=None,
+                          conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The updated Connection
+        """
+        endpoint = '/api/experimental/connections/'
+        url = urljoin(self._api_base_url, endpoint)
+        conn = self._request(url, method='PATCH', json={
+            'conn_id': conn_id,
+            'conn_uri': conn_uri,
+            'conn_type': conn_type,
+            'conn_host': conn_host,
+            'conn_login': conn_login,
+            'conn_password': conn_password,
+            'conn_schema': conn_schema,
+            'conn_port': conn_port,
+            'conn_extra': conn_extra})
+        return conn.to_json()

--- a/airflow/api/client/local_client.py
+++ b/airflow/api/client/local_client.py
@@ -18,7 +18,7 @@
 # under the License.
 
 from airflow.api.client import api_client
-from airflow.api.common.experimental import pool
+from airflow.api.common.experimental import pool, connections
 from airflow.api.common.experimental import trigger_dag
 from airflow.api.common.experimental import delete_dag
 
@@ -51,3 +51,83 @@ class Client(api_client.Client):
     def delete_pool(self, name):
         p = pool.delete_pool(name=name)
         return p.pool, p.slots, p.description
+
+    def add_connection(self, conn_id,
+                       conn_uri=None,
+                       conn_type=None,
+                       conn_host=None,
+                       conn_login=None,
+                       conn_password=None,
+                       conn_schema=None,
+                       conn_port=None,
+                       conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The new Connection
+        """
+        return connections.add_connection(conn_id,
+                                          conn_uri,
+                                          conn_type,
+                                          conn_host,
+                                          conn_login,
+                                          conn_password,
+                                          conn_schema,
+                                          conn_port,
+                                          conn_extra).to_json()
+
+    def delete_connection(self, conn_id, delete_all=False):
+        """
+
+        :param conn_id:
+        :param delete_all:
+        :return: the conn_id(s) of the Connection(s) that were removed
+        """
+        return connections.delete_connection(conn_id, delete_all)
+
+    def list_connections(self):
+        """
+
+        :return: All Connections
+        """
+        return [conn.to_json() for conn in connections.list_connections()]
+
+    def update_connection(self, conn_id,
+                          conn_uri=None,
+                          conn_type=None,
+                          conn_host=None,
+                          conn_login=None,
+                          conn_password=None,
+                          conn_schema=None,
+                          conn_port=None,
+                          conn_extra=None):
+        """
+
+        :param conn_id:
+        :param conn_uri:
+        :param conn_type:
+        :param conn_host:
+        :param conn_login:
+        :param conn_password:
+        :param conn_schema:
+        :param conn_port:
+        :param conn_extra:
+        :return: The updated Connection
+        """
+        return connections.update_connection(conn_id,
+                                             conn_uri,
+                                             conn_type,
+                                             conn_host,
+                                             conn_login,
+                                             conn_password,
+                                             conn_schema,
+                                             conn_port,
+                                             conn_extra).to_json()

--- a/airflow/api/common/experimental/connections.py
+++ b/airflow/api/common/experimental/connections.py
@@ -1,0 +1,225 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from sqlalchemy.orm import exc
+from airflow import settings
+from airflow.exceptions import MissingArgument, ConnectionNotFound, MultipleConnectionsFound, \
+    IncompatibleArgument
+from airflow.models.connection import Connection
+
+
+def add_connection(
+    conn_id,
+    conn_uri=None,
+    conn_type=None,
+    conn_host=None,
+    conn_login=None,
+    conn_password=None,
+    conn_schema=None,
+    conn_port=None,
+    conn_extra=None,
+):
+    # Check that the conn_id and conn_uri args were passed to the command:
+    missing_args = list()
+    invalid_args = list()
+    if not conn_id:
+        missing_args.append('conn_id')
+
+    if conn_uri:
+        if conn_type:
+            invalid_args.append(conn_type)
+        if conn_host:
+            invalid_args.append(conn_host)
+        if conn_login:
+            invalid_args.append(conn_login)
+        if conn_password:
+            invalid_args.append(conn_password)
+        if conn_schema:
+            invalid_args.append(conn_schema)
+        if conn_port:
+            invalid_args.append(conn_port)
+    elif not conn_type:
+        missing_args.append('conn_uri or conn_type')
+
+    if missing_args:
+        msg = ('The following args are required to add a connection:' +
+               ' {missing!r}'.format(missing=missing_args))
+        raise MissingArgument(msg)
+    if invalid_args:
+        msg = ('The following args are not compatible with the ' +
+               '--add flag and --conn_uri flag: {invalid!r}')
+        msg = msg.format(invalid=invalid_args)
+        raise MissingArgument(msg)
+
+    if conn_uri:
+        new_conn = Connection(conn_id=conn_id, uri=conn_uri)
+    else:
+        new_conn = Connection(conn_id=conn_id,
+                              conn_type=conn_type,
+                              host=conn_host,
+                              login=conn_login,
+                              password=conn_password,
+                              schema=conn_schema,
+                              port=conn_port)
+    if conn_extra is not None:
+        new_conn.set_extra(conn_extra)
+
+    session = settings.Session()
+    existing_connections = (session
+                            .query(Connection)
+                            .filter(Connection.conn_id == conn_id)).all()
+
+    if not all(c.conn_type == new_conn.conn_type for c in existing_connections):
+        raise IncompatibleArgument('Connections with the same id must all be of the same type')
+
+    session.add(new_conn)
+    session.commit()
+    return new_conn
+
+
+def delete_connection(conn_id, delete_all=False):
+
+    if conn_id is None:
+        raise MissingArgument('To delete a connection, you must provide a value for ' +
+                              'the --conn_id flag.')
+
+    session = settings.Session()
+    to_delete = (session
+                 .query(Connection)
+                 .filter(Connection.conn_id == conn_id)).all()
+
+    if len(to_delete) == 1:
+        deleted_conn_id = to_delete[0].conn_id
+        for conn in to_delete:
+            session.delete(conn)
+        session.commit()
+        msg = 'Successfully deleted `conn_id`={conn_id}'
+        msg = msg.format(conn_id=deleted_conn_id)
+        return msg
+    elif len(to_delete) > 1:
+        if delete_all:
+            deleted_conn_id = to_delete[0].conn_id
+            num_conns = len(to_delete)
+            for conn in to_delete:
+                session.delete(conn)
+            session.commit()
+
+            msg = 'Successfully deleted {num_conns} connections with `conn_id`={conn_id}'
+            msg = msg.format(conn_id=deleted_conn_id, num_conns=num_conns)
+            return msg
+        else:
+            msg = ('Found {num_conns} connection with ' +
+                   '`conn_id`={conn_id}. Specify `delete_all=True` to remove all')
+            msg = msg.format(conn_id=conn_id, num_conns=len(to_delete))
+            return msg
+    elif len(to_delete) == 0:
+        msg = 'Did not find a connection with `conn_id`={conn_id}'
+        msg = msg.format(conn_id=conn_id)
+        return msg
+
+
+def list_connections():
+    session = settings.Session()
+    return session.query(Connection).all()
+
+
+def update_connection(conn_id,
+                      conn_uri=None,
+                      conn_type=None,
+                      conn_host=None,
+                      conn_login=None,
+                      conn_password=None,
+                      conn_schema=None,
+                      conn_port=None,
+                      conn_extra=None):
+    # Check that the conn_id and conn_uri args were passed to the command:
+    missing_args = list()
+    invalid_args = list()
+    if not conn_id:
+        missing_args.append('conn_id')
+    if conn_uri:
+        if conn_type:
+            invalid_args.append(conn_type)
+        if conn_host:
+            invalid_args.append(conn_host)
+        if conn_login:
+            invalid_args.append(conn_login)
+        if conn_password:
+            invalid_args.append(conn_password)
+        if conn_schema:
+            invalid_args.append(conn_schema)
+        if conn_port:
+            invalid_args.append(conn_port)
+    elif not conn_type:
+        missing_args.append('conn_uri or conn_type')
+
+    if missing_args:
+        msg = ('The following args are required to update a connection:' +
+               ' {missing!r}'.format(missing=missing_args))
+        raise MissingArgument(msg)
+    if invalid_args:
+        msg = ('The following args are not compatible with the ' +
+               '--update flag and --conn_uri flag: {invalid!r}')
+        msg = msg.format(invalid=invalid_args)
+        raise MissingArgument(msg)
+
+    # Update....
+    session = settings.Session()
+    try:
+        to_update = (session
+                     .query(Connection)
+                     .filter(Connection.conn_id == conn_id)
+                     .one())
+    except exc.NoResultFound:
+        msg = 'Did not find a connection with `conn_id`={conn_id}'
+        msg = msg.format(conn_id=conn_id)
+        raise ConnectionNotFound(msg)
+    except exc.MultipleResultsFound:
+        msg = ('Updating multiple connections is not supported, Found multiple connections with ' +
+               '`conn_id`={conn_id}')
+        msg = msg.format(conn_id=conn_id)
+        raise MultipleConnectionsFound(msg)
+    else:
+
+        # build a new connection to update from
+        if conn_uri:
+            temp_conn = Connection(conn_id='new_conn', uri=conn_uri)
+        else:
+            temp_conn = Connection(conn_id='new_conn',
+                                   conn_type=conn_type,
+                                   host=conn_host,
+                                   login=conn_login,
+                                   password=conn_password,
+                                   schema=conn_schema,
+                                   port=conn_port)
+        if conn_extra is not None:
+            temp_conn.set_extra(conn_extra)
+
+        to_update.conn_type = temp_conn.conn_type or to_update.conn_type
+        to_update.host = temp_conn.host or to_update.host
+        to_update.login = temp_conn.login or to_update.login
+        to_update.password = temp_conn.password or to_update.password
+        to_update.schema = temp_conn.schema or to_update.schema
+        to_update.port = temp_conn.port or to_update.port
+
+        if temp_conn.extra is not None:
+            to_update.set_extra(temp_conn.extra)
+        session.commit()
+
+        return to_update

--- a/airflow/bin/cli.py
+++ b/airflow/bin/cli.py
@@ -47,16 +47,15 @@ import traceback
 import time
 import psutil
 import re
-from urllib.parse import urlunparse
 
 import airflow
 from airflow import api
 from airflow import jobs, settings
 from airflow import configuration as conf
-from airflow.exceptions import AirflowException, AirflowWebServerTimeout
+from airflow.exceptions import AirflowException, AirflowWebServerTimeout, MissingArgument, \
+    MultipleConnectionsFound, ConnectionNotFound
 from airflow.executors import GetDefaultExecutor
 from airflow.models import DagModel, DagBag, TaskInstance, DagRun, Variable, DAG
-from airflow.models.connection import Connection
 from airflow.models.dagpickle import DagPickle
 from airflow.ti_deps.dep_context import (DepContext, SCHEDULER_DEPS)
 from airflow.utils import cli as cli_utils, db
@@ -68,7 +67,6 @@ from airflow.www_rbac.app import cached_app as cached_app_rbac
 from airflow.www_rbac.app import create_app as create_app_rbac
 from airflow.www_rbac.app import cached_appbuilder
 
-from sqlalchemy.orm import exc
 
 api.load_auth()
 api_module = import_module(conf.get('cli', 'api_client'))
@@ -1110,133 +1108,77 @@ alternative_conn_specs = ['conn_type', 'conn_host',
 @cli_utils.action_logging
 def connections(args):
     if args.list:
-        # Check that no other flags were passed to the command
-        invalid_args = list()
-        for arg in ['conn_id', 'conn_uri', 'conn_extra'] + alternative_conn_specs:
-            if getattr(args, arg) is not None:
-                invalid_args.append(arg)
-        if invalid_args:
-            msg = ('\n\tThe following args are not compatible with the ' +
-                   '--list flag: {invalid!r}\n')
-            msg = msg.format(invalid=invalid_args)
-            print(msg)
-            return
-
-        with db.create_session() as session:
-            conns = session.query(Connection.conn_id, Connection.conn_type,
-                                  Connection.host, Connection.port,
-                                  Connection.is_encrypted,
-                                  Connection.is_extra_encrypted,
-                                  Connection.extra).all()
-            conns = [map(reprlib.repr, conn) for conn in conns]
-            msg = tabulate(conns, ['Conn Id', 'Conn Type', 'Host', 'Port',
-                                   'Is Encrypted', 'Is Extra Encrypted', 'Extra'],
-                           tablefmt="fancy_grid")
-            if sys.version_info[0] < 3:
-                msg = msg.encode('utf-8')
-            print(msg)
-            return
+        conns = api_client.list_connections()
+        # format it for the cli
+        conns = list(map(lambda c: (c['conn_id'], c['conn_type'],
+                                    c['host'], c['port'],
+                                    c['is_encrypted'],
+                                    c['is_extra_encrypted'],
+                                    c['extra']), conns))
+        conns = [map(reprlib.repr, conn) for conn in conns]
+        msg = tabulate(conns, ['Conn Id', 'Conn Type', 'Host', 'Port',
+                               'Is Encrypted', 'Is Extra Encrypted', 'Extra'],
+                       tablefmt="fancy_grid")
+        if sys.version_info[0] < 3:
+            msg = msg.encode('utf-8')
+        print(msg)
+        return
 
     if args.delete:
-        # Check that only the `conn_id` arg was passed to the command
-        invalid_args = list()
-        for arg in ['conn_uri', 'conn_extra'] + alternative_conn_specs:
-            if getattr(args, arg) is not None:
-                invalid_args.append(arg)
-        if invalid_args:
-            msg = ('\n\tThe following args are not compatible with the ' +
-                   '--delete flag: {invalid!r}\n')
-            msg = msg.format(invalid=invalid_args)
-            print(msg)
-            return
-
-        if args.conn_id is None:
-            print('\n\tTo delete a connection, you Must provide a value for ' +
-                  'the --conn_id flag.\n')
-            return
-
-        with db.create_session() as session:
-            try:
-                to_delete = (session
-                             .query(Connection)
-                             .filter(Connection.conn_id == args.conn_id)
-                             .one())
-            except exc.NoResultFound:
-                msg = '\n\tDid not find a connection with `conn_id`={conn_id}\n'
-                msg = msg.format(conn_id=args.conn_id)
-                print(msg)
-                return
-            except exc.MultipleResultsFound:
-                msg = ('\n\tFound more than one connection with ' +
-                       '`conn_id`={conn_id}\n')
-                msg = msg.format(conn_id=args.conn_id)
-                print(msg)
-                return
-            else:
-                deleted_conn_id = to_delete.conn_id
-                session.delete(to_delete)
-                msg = '\n\tSuccessfully deleted `conn_id`={conn_id}\n'
-                msg = msg.format(conn_id=deleted_conn_id)
-                print(msg)
-            return
+        try:
+            print(api_client.delete_connection(args.conn_id, args.delete_all))
+        except MissingArgument as ma:
+            print(ma)
+        return
 
     if args.add:
-        # Check that the conn_id and conn_uri args were passed to the command:
-        missing_args = list()
-        invalid_args = list()
-        if not args.conn_id:
-            missing_args.append('conn_id')
-        if args.conn_uri:
-            for arg in alternative_conn_specs:
-                if getattr(args, arg) is not None:
-                    invalid_args.append(arg)
-        elif not args.conn_type:
-            missing_args.append('conn_uri or conn_type')
-        if missing_args:
-            msg = ('\n\tThe following args are required to add a connection:' +
-                   ' {missing!r}\n'.format(missing=missing_args))
-            print(msg)
-        if invalid_args:
-            msg = ('\n\tThe following args are not compatible with the ' +
-                   '--add flag and --conn_uri flag: {invalid!r}\n')
-            msg = msg.format(invalid=invalid_args)
-            print(msg)
-        if missing_args or invalid_args:
-            return
+        try:
+            new_conn = api_client.add_connection(
+                conn_id=args.conn_id,
+                conn_uri=args.conn_uri,
+                conn_type=args.conn_type,
+                conn_host=args.conn_host,
+                conn_login=args.conn_login,
+                conn_password=args.conn_password,
+                conn_schema=args.conn_schema,
+                conn_port=args.conn_port,
+                conn_extra=args.conn_extra)
 
-        if args.conn_uri:
-            new_conn = Connection(conn_id=args.conn_id, uri=args.conn_uri)
+        except MissingArgument as ma:
+            print(ma)
         else:
-            new_conn = Connection(conn_id=args.conn_id,
-                                  conn_type=args.conn_type,
-                                  host=args.conn_host,
-                                  login=args.conn_login,
-                                  password=args.conn_password,
-                                  schema=args.conn_schema,
-                                  port=args.conn_port)
-        if args.conn_extra is not None:
-            new_conn.set_extra(args.conn_extra)
+            # format success message!
+            msg = 'Successfully added `conn_id`={conn_id} : {uri}\n'
+            msg = msg.format(conn_id=new_conn['conn_id'],
+                             uri=new_conn['uri'])
+            print(msg)
+        return
 
-        with db.create_session() as session:
-            if not (session.query(Connection)
-                           .filter(Connection.conn_id == new_conn.conn_id).first()):
-                session.add(new_conn)
-                msg = '\n\tSuccessfully added `conn_id`={conn_id} : {uri}\n'
-                msg = msg.format(conn_id=new_conn.conn_id,
-                                 uri=args.conn_uri or
-                                 urlunparse((args.conn_type,
-                                            '{login}:{password}@{host}:{port}'
-                                             .format(login=args.conn_login or '',
-                                                     password=args.conn_password or '',
-                                                     host=args.conn_host or '',
-                                                     port=args.conn_port or ''),
-                                             args.conn_schema or '', '', '', '')))
-                print(msg)
-            else:
-                msg = '\n\tA connection with `conn_id`={conn_id} already exists\n'
-                msg = msg.format(conn_id=new_conn.conn_id)
-                print(msg)
+    if args.update:
+        try:
+            new_conn = api_client.update_connection(
+                conn_id=args.conn_id,
+                conn_uri=args.conn_uri,
+                conn_type=args.conn_type,
+                conn_host=args.conn_host,
+                conn_login=args.conn_login,
+                conn_password=args.conn_password,
+                conn_schema=args.conn_schema,
+                conn_port=args.conn_port,
+                conn_extra=args.conn_extra)
 
+        except MissingArgument as ma:
+            print(ma)
+        except MultipleConnectionsFound as mcf:
+            print(mcf)
+        except ConnectionNotFound as cnf:
+            print(cnf)
+        else:
+            # format success message!
+            msg = 'Successfully updated `conn_id`={conn_id} : {uri}\n'
+            msg = msg.format(conn_id=new_conn['conn_id'],
+                             uri=new_conn['uri'])
+            print(msg)
         return
 
 
@@ -1821,6 +1763,10 @@ class CLIFactory(object):
             ('-d', '--delete'),
             help='Delete a connection',
             action='store_true'),
+        'update_connection': Arg(
+            ('-u', '--update'),
+            help='Update a connection',
+            action='store_true'),
         'conn_id': Arg(
             ('--conn_id',),
             help='Connection id, required to add/delete a connection',
@@ -1857,6 +1803,11 @@ class CLIFactory(object):
             ('--conn_extra',),
             help='Connection `Extra` field, optional when adding a connection',
             type=str),
+        'delete_all': Arg(
+            ('--delete_all',),
+            help='Flag to indicate if multiple connections should be deleted',
+            action="store_true",
+            default=False),
         # users
         'username': Arg(
             ('--username',),
@@ -2059,9 +2010,11 @@ class CLIFactory(object):
             'args': tuple(),
         }, {
             'func': connections,
-            'help': "List/Add/Delete connections",
-            'args': ('list_connections', 'add_connection', 'delete_connection',
-                     'conn_id', 'conn_uri', 'conn_extra') + tuple(alternative_conn_specs),
+            'help': "List/Add/Update/Delete connections",
+            'args': ('list_connections', 'add_connection', 'update_connection',
+                     'delete_connection', 'conn_id', 'conn_uri',
+                     'conn_extra', 'conn_type', 'conn_host',
+                     'conn_login', 'conn_password', 'conn_schema', 'conn_port', 'delete_all'),
         }, {
             'func': users,
             'help': "List/Create/Delete users",

--- a/airflow/exceptions.py
+++ b/airflow/exceptions.py
@@ -107,3 +107,23 @@ class TaskInstanceNotFound(AirflowNotFoundException):
 class PoolNotFound(AirflowNotFoundException):
     """Raise when a Pool is not available in the system"""
     pass
+
+
+class MissingArgument(AirflowBadRequest):
+    """Raise when a required argument is missing"""
+    pass
+
+
+class IncompatibleArgument(AirflowBadRequest):
+    """Raise when one or more argument(s) are incompatible"""
+    pass
+
+
+class ConnectionNotFound(AirflowNotFoundException):
+    """Raise when a connection is not found"""
+    pass
+
+
+class MultipleConnectionsFound(AirflowBadRequest):
+    """Raise when multiple connections are found"""
+    pass

--- a/airflow/www/api/experimental/endpoints.py
+++ b/airflow/www/api/experimental/endpoints.py
@@ -23,6 +23,7 @@ from flask import (
 import airflow.api
 from airflow.api.common.experimental import delete_dag as delete
 from airflow.api.common.experimental import pool as pool_api
+from airflow.api.common.experimental import connections as connection_api
 from airflow.api.common.experimental import trigger_dag as trigger
 from airflow.api.common.experimental.get_task import get_task
 from airflow.api.common.experimental.get_task_instance import get_task_instance
@@ -253,3 +254,70 @@ def delete_pool(name):
         return response
     else:
         return jsonify(pool.to_json())
+
+
+@csrf.exempt
+@api_experimental.route('/connections', methods=['GET'])
+@requires_authentication
+def list_connections():
+    """Get all connections."""
+    try:
+        connections = connection_api.list_connections()
+    except AirflowException as err:
+        _log.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = err.status_code
+        return response
+    else:
+        return jsonify([c.to_json() for c in connections])
+
+
+@csrf.exempt
+@api_experimental.route('/connections/<string:conn_id>', methods=['DELETE'])
+@requires_authentication
+def delete_connection(conn_id):
+    """Delete pool."""
+    params = request.get_json(force=True)
+    try:
+        msg = connection_api.delete_connection(conn_id=conn_id, **params)
+    except AirflowException as err:
+        _log.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = err.status_code
+        return response
+    else:
+        return jsonify({"success": msg})
+
+
+@csrf.exempt
+@api_experimental.route('/connections', methods=['POST'])
+@requires_authentication
+def add_connection():
+    """Delete pool."""
+    params = request.get_json(force=True)
+    try:
+        new_conn = connection_api.add_connection(**params)
+    except AirflowException as err:
+        _log.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = err.status_code
+        return response
+    else:
+        return jsonify(new_conn.to_json())
+
+
+@csrf.exempt
+@api_experimental.route('/connections', methods=['PATCH'])
+@requires_authentication
+def update_connection():
+    """Delete pool."""
+    params = request.get_json(force=True)
+    try:
+        new_conn = connection_api.update_connection(**params)
+    except AirflowException as err:
+        _log.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = err.status_code
+        return response
+    else:
+        return jsonify(new_conn.to_json())

--- a/airflow/www_rbac/api/experimental/endpoints.py
+++ b/airflow/www_rbac/api/experimental/endpoints.py
@@ -19,6 +19,7 @@
 import airflow.api
 
 from airflow.api.common.experimental import pool as pool_api
+from airflow.api.common.experimental import connections as connection_api
 from airflow.api.common.experimental import trigger_dag as trigger
 from airflow.api.common.experimental.get_dag_runs import get_dag_runs
 from airflow.api.common.experimental.get_task import get_task
@@ -319,3 +320,70 @@ def delete_pool(name):
         return response
     else:
         return jsonify(pool.to_json())
+
+
+@csrf.exempt
+@api_experimental.route('/connections', methods=['GET'])
+@requires_authentication
+def list_connections():
+    """Get all connections."""
+    try:
+        connections = connection_api.list_connections()
+    except AirflowException as err:
+        _log.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = err.status_code
+        return response
+    else:
+        return jsonify([c.to_json() for c in connections])
+
+
+@csrf.exempt
+@api_experimental.route('/connections/<string:conn_id>', methods=['DELETE'])
+@requires_authentication
+def delete_connection(conn_id):
+    """Delete connections."""
+    params = request.get_json(force=True)
+    try:
+        msg = connection_api.delete_connection(conn_id=conn_id, **params)
+    except AirflowException as err:
+        _log.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = err.status_code
+        return response
+    else:
+        return jsonify({"success": msg})
+
+
+@csrf.exempt
+@api_experimental.route('/connections', methods=['POST'])
+@requires_authentication
+def add_connection():
+    """Delete connection."""
+    params = request.get_json(force=True)
+    try:
+        new_conn = connection_api.add_connection(**params)
+    except AirflowException as err:
+        _log.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = err.status_code
+        return response
+    else:
+        return jsonify(new_conn.to_json())
+
+
+@csrf.exempt
+@api_experimental.route('/connections', methods=['PATCH'])
+@requires_authentication
+def update_connection():
+    """Delete connection."""
+    params = request.get_json(force=True)
+    try:
+        new_conn = connection_api.update_connection(**params)
+    except AirflowException as err:
+        _log.error(err)
+        response = jsonify(error="{}".format(err))
+        response.status_code = err.status_code
+        return response
+    else:
+        return jsonify(new_conn.to_json())

--- a/tests/api/common/experimental/connection_tests.py
+++ b/tests/api/common/experimental/connection_tests.py
@@ -1,0 +1,427 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+from airflow import settings, models
+from airflow.api.common.experimental import connections
+from airflow.exceptions import MissingArgument, MultipleConnectionsFound, IncompatibleArgument
+from airflow.models import Connection
+from airflow.settings import Session
+
+
+class ConnectionTests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super(ConnectionTests, cls).setUpClass()
+        cls._cleanup()
+
+    def setUp(self):
+        super(ConnectionTests, self).setUp()
+        # from airflow.www_rbac import app as application
+        # configuration.load_test_config()
+        # self.app, self.appbuilder = application.create_app(session=Session, testing=True)
+        # self.app.config['TESTING'] = True
+
+        # self.dagbag = models.DagBag(dag_folder=DEV_NULL, include_examples=True)
+        settings.configure_orm()
+        self.session = Session
+
+    def tearDown(self):
+        self._cleanup(session=self.session)
+        super(ConnectionTests, self).tearDown()
+
+    @staticmethod
+    def _cleanup(session=None):
+        if session is None:
+            session = Session()
+
+        session.query(models.Pool).delete()
+        session.query(models.Variable).delete()
+        session.query(models.Connection).delete()
+        session.commit()
+        session.close()
+
+    def test_add_connection(self):
+        uri = 'postgres://airflow:airflow@host:5432/airflow'
+        # add a connection using conn_uri
+        self.assertEqual(connections.add_connection(
+            conn_id="new1",
+            conn_uri=uri
+        ), Connection(conn_id="new1", uri=uri))
+
+        # add a connection with all params defined
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_type="postgres",
+            conn_host="host",
+            conn_login="airflow",
+            conn_password="airflow",
+            conn_schema="airflow",
+            conn_port="5432"
+        ), Connection(
+            conn_id="new2",
+            conn_type="postgres",
+            host="host",
+            login="airflow",
+            password="airflow",
+            schema="airflow",
+            port="5432"))
+
+        # add a connection with extra
+        con3_test = Connection(conn_id="new3", uri=uri)
+        con3_test.set_extra("{'foo':'bar'}")
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'foo':'bar'}"
+        ), con3_test)
+
+        # add a duplicate connection`
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'foo':'bar'}"
+        ), con3_test)
+
+        # add a connection with just type
+        self.assertEqual(connections.add_connection(
+            conn_id="new4",
+            conn_type="google_cloud_platform",
+            conn_uri="",
+            conn_extra="{'extra':'yes'}"
+        ), Connection(conn_id="new4",
+                      conn_type="google_cloud_platform",
+                      uri="",
+                      extra="{'extra':'yes'}"))
+
+        # Attempt to add without providing conn_id
+        with self.assertRaises(MissingArgument) as ma:
+            connections.add_connection(conn_id=None, conn_uri=uri)
+            self.assertEqual(ma.exception,
+                             "The following args are required to add a connection:" +
+                             " ['conn_id']")
+
+        # Attempt to add without providing conn_uri
+        with self.assertRaises(MissingArgument) as ma:
+            connections.add_connection(conn_id="new5")
+            self.assertEqual(ma.exception,
+                             "The following args are required to add a connection:" +
+                             " ['conn_id or conn_type']")
+
+        # Attempt to add duplicate connection with different type
+        with self.assertRaises(IncompatibleArgument) as ia:
+            connections.add_connection(conn_id="new2",
+                                       conn_type="not_postgres",
+                                       conn_host="host",
+                                       conn_login="airflow",
+                                       conn_password="airflow",
+                                       conn_schema="airflow",
+                                       conn_port="5432")
+            self.assertEqual(ia.exception, "Connections with the same id must all be of the same type")
+
+        # validate expected connections reached the DB
+        session = settings.Session()
+        extra = {'new1': None,
+                 'new2': None,
+                 'new3': "{'foo':'bar'}", }
+
+        for index in range(1, 5):
+            conn_id = 'new%s' % index
+            result = (session
+                      .query(models.Connection)
+                      .filter(models.Connection.conn_id == conn_id)
+                      .first())
+            result = (result.conn_id, result.conn_type, result.host,
+                      result.port, result.get_extra())
+            if conn_id in ['new1', 'new2', 'new3']:
+                self.assertEqual(result, (conn_id, 'postgres', 'host', 5432,
+                                          extra[conn_id]))
+            elif conn_id == 'new4':
+                print('result: ', result)
+                self.assertEqual(result, (conn_id, 'google_cloud_platform',
+                                          None, None, "{'extra':'yes'}"))
+
+        # validate duplicate connections made it to the db
+        dup_conns = (session
+                     .query(models.Connection)
+                     .filter(models.Connection.conn_id == 'new3')).all()
+        print(dup_conns)
+        self.assertEqual(2, len(dup_conns))
+        for conn in dup_conns:
+            result = (conn.conn_id, conn.conn_type, conn.host,
+                      conn.port, conn.get_extra())
+            self.assertEqual(result, ('new3', 'postgres', 'host', 5432,
+                                      extra['new3']))
+
+    def test_delete_connection(self):
+        session = settings.Session()
+        # add some conns to delete
+        uri = 'postgres://airflow:airflow@host:5432/airflow'
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new1",
+            conn_uri=uri
+        ), Connection(conn_id="new1", uri=uri))
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_uri=uri
+        ), Connection(conn_id="new2", uri=uri))
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_uri=uri
+        ), Connection(conn_id="new2", uri=uri))
+
+        # delete one
+        self.assertEqual(connections.delete_connection(conn_id='new1'),
+                         "Successfully deleted `conn_id`=new1")
+
+        # try to delete multiple with delete_all=False
+        self.assertEqual(connections.delete_connection(conn_id='new2'),
+                         'Found 2 connection with ' +
+                         '`conn_id`=new2. Specify `delete_all=True` to remove all')
+
+        # make sure none were deleted
+        self.assertEqual(2, len((session.query(models.Connection)
+                                 .filter(models.Connection.conn_id == 'new2').all())))
+
+        self.assertEqual(connections.delete_connection(conn_id='new2', delete_all=True),
+                         "Successfully deleted 2 connections with `conn_id`=new2")
+
+        # make sure none were deleted
+        self.assertEqual(0, len((session.query(models.Connection).all())))
+
+        # Attempt to delete a non-existing connnection
+        self.assertEqual(connections.delete_connection(conn_id='non_existent'),
+                         "Did not find a connection with `conn_id`=non_existent")
+
+        # Attempt to delete a non-existing connnection
+        self.assertRaises(MissingArgument, connections.delete_connection, None)
+
+        session.close()
+
+    def test_list_connections(self):
+
+        uri = 'postgres://airflow:airflow@host:5432/airflow'
+
+        # add a connection using conn_uri
+        self.assertEqual(connections.add_connection(
+            conn_id="new1",
+            conn_uri=uri
+        ), Connection(conn_id="new1", uri=uri))
+
+        # add a connection with all params defined
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_type="postgres",
+            conn_host="host",
+            conn_login="airflow",
+            conn_password="airflow",
+            conn_schema="airflow",
+            conn_port="5432"
+        ), Connection(
+            conn_id="new2",
+            conn_type="postgres",
+            host="host",
+            login="airflow",
+            password="airflow",
+            schema="airflow",
+            port="5432"
+        ))
+
+        # add a connection with extra
+        con3 = Connection(conn_id="new3",
+                          uri=uri, )
+        con3.set_extra("{'bar':'foo'}")
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'bar':'foo'}"
+        ), con3)
+
+        # add a duplicate connection`
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'bar':'foo'}"
+        ), con3)
+
+        # add a connection with just type
+        con4 = Connection(conn_id="new4",
+                          conn_type="google_cloud_platform")
+        con4.set_extra("{'extra':'yes'}")
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new4",
+            conn_type="google_cloud_platform",
+            conn_uri="",
+            conn_extra="{'extra':'yes'}"
+        ), con4)
+
+        conns = list(map(lambda conn: (conn.conn_id, conn.conn_type, conn.host,
+                                       conn.port, conn.is_extra_encrypted),
+                         connections.list_connections()))
+
+        self.assertEqual(conns,
+                         [('new1', 'postgres', 'host', 5432, False),
+                          ('new2', 'postgres', 'host', 5432, False),
+                          ('new3', 'postgres', 'host', 5432, True),
+                          ('new3', 'postgres', 'host', 5432, True),
+                          ('new4', 'google_cloud_platform', None, None, True)])
+
+    def test_update_connection(self):
+        uri = 'postgres://airflow:airflow@host:5432/airflow'
+
+        # add a connection using conn_uri
+        self.assertEqual(connections.add_connection(
+            conn_id="new1",
+            conn_uri=uri
+        ), Connection(conn_id="new1", uri=uri))
+
+        # add a connection with all params defined
+        self.assertEqual(connections.add_connection(
+            conn_id="new2",
+            conn_type="postgres",
+            conn_host="host",
+            conn_login="airflow",
+            conn_password="airflow",
+            conn_schema="airflow",
+            conn_port="5432"
+        ), Connection(
+            conn_id="new2",
+            conn_type="postgres",
+            host="host",
+            login="airflow",
+            password="airflow",
+            schema="airflow",
+            port="5432"
+        ))
+
+        # add a connection with extra
+        con3 = Connection(conn_id="new3",
+                          uri=uri, )
+        con3.set_extra("{'bar':'foo'}")
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'bar':'foo'}"
+        ), con3)
+
+        # add a duplicate connection`
+        self.assertEqual(connections.add_connection(
+            conn_id="new3",
+            conn_uri=uri,
+            conn_extra="{'bar':'foo'}"
+        ), con3)
+
+        # add a connection with just type
+        con4 = Connection(conn_id="new4",
+                          conn_type="google_cloud_platform")
+        con4.set_extra("{'extra':'yes'}")
+
+        self.assertEqual(connections.add_connection(
+            conn_id="new4",
+            conn_type="google_cloud_platform",
+            conn_uri="",
+            conn_extra="{'extra':'yes'}"
+        ), con4)
+
+        # Update Connections
+        new_uri = 'postgres://airflow:different_password@host:1234/airflow'
+        # update connection using conn_uri
+        self.assertEqual(connections.update_connection(
+            conn_id="new1",
+            conn_uri=new_uri
+        ), Connection(conn_id="new1",
+                      uri=new_uri))
+
+        # update connection with all params defined
+        self.assertEqual(connections.update_connection(
+            conn_id="new2",
+            conn_type="postgres",
+            conn_host="host",
+            conn_login="airflow",
+            conn_password="different_password",
+            conn_schema="airflow",
+            conn_port="1234"
+        ), Connection(conn_id="new2",
+                      conn_type="postgres",
+                      host="host",
+                      login="airflow",
+                      password="different_password",
+                      schema="airflow",
+                      port="1234"))
+
+        # update connection with just type
+        con4 = Connection(conn_id="new4",
+                          conn_type="random_type")
+        con4.set_extra("{'extra':'yes'}")
+
+        self.assertEqual(connections.update_connection(
+            conn_id="new4",
+            conn_type="random_type",
+            conn_uri="",
+            conn_extra="{'extra':'yes'}"
+        ), con4)
+
+        # validate updates reached the DB
+        session = settings.Session()
+        extra = {'new1': None,
+                 'new2': None,
+                 'new3': "{'bar':'foo'}",
+                 'new4': "{'extra': 'yes'}", }
+
+        for index in range(1, 4):
+            conn_id = 'new%s' % index
+            result = (session
+                      .query(models.Connection)
+                      .filter(models.Connection.conn_id == conn_id)
+                      .first())
+            result = (result.conn_id, result.conn_type, result.host,
+                      result.port, result.get_extra())
+            if conn_id in ['new1', 'new2']:
+                self.assertEqual(result, (conn_id, 'postgres', 'host', 1234,
+                                          extra[conn_id]))
+            elif conn_id == 'new4':
+                print('result: ', result)
+                self.assertEqual(result, (conn_id, 'random_type',
+                                          None, None, extra[conn_id]))
+
+        # try to update duplicate connection
+        self.assertRaises(MultipleConnectionsFound, connections.update_connection, conn_id="new3",
+                          conn_uri=new_uri,
+                          conn_extra="{'foo':'bar'}")
+
+        # validate duplicate connections did not update in db
+        dup_conns = (session
+                     .query(models.Connection)
+                     .filter(models.Connection.conn_id == 'new3')).all()
+        self.assertEqual(2, len(dup_conns))
+        for conn in dup_conns:
+            result = (conn.conn_id, conn.conn_type, conn.host,
+                      conn.port, conn.get_extra())
+            self.assertEqual(result, ('new3', 'postgres', 'host', 5432,
+                                      extra['new3']))
+
+        # Attempt to udpate without providing conn_uri
+        self.assertRaises(MissingArgument, connections.update_connection, conn_id="new1")

--- a/tests/core.py
+++ b/tests/core.py
@@ -147,7 +147,7 @@ class CoreTest(unittest.TestCase):
             datetime(2015, 1, 2, 0, 0),
             dag_run.execution_date,
             msg='dag_run.execution_date did not match expectation: {0}'
-            .format(dag_run.execution_date)
+                .format(dag_run.execution_date)
         )
         self.assertEqual(State.RUNNING, dag_run.state)
         self.assertFalse(dag_run.external_trigger)
@@ -1089,6 +1089,7 @@ class CliTests(unittest.TestCase):
 
         session.query(models.Pool).delete()
         session.query(models.Variable).delete()
+        session.query(Connection).delete()
         session.commit()
         session.close()
 
@@ -1176,7 +1177,36 @@ class CliTests(unittest.TestCase):
 
         resetdb_mock.assert_called_once_with(False)
 
-    def test_cli_connections_list(self):
+    def test_cli_list_connections(self):
+        uri = 'postgresql://airflow:airflow@host:5432/airflow'
+
+        cli.connections(self.parser.parse_args(
+            ['connections', '--add', '--conn_id=new1',
+             '--conn_uri=%s' % uri]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '-a', '--conn_id=new2',
+             '--conn_uri=%s' % uri]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '--add', '--conn_id=new3',
+             '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '-a', '--conn_id=new4',
+             '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '--add', '--conn_id=new5',
+             '--conn_type=hive_metastore', '--conn_login=airflow',
+             '--conn_password=airflow', '--conn_host=host',
+             '--conn_port=9083', '--conn_schema=airflow']))
+        cli.connections(self.parser.parse_args(
+            ['connections', '-a', '--conn_id=new6',
+             '--conn_uri', "", '--conn_type=google_cloud_platform', '--conn_extra', "{'extra': 'yes'}"]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '--add', '--conn_id=duplicate1',
+             '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+        cli.connections(self.parser.parse_args(
+            ['connections', '-a', '--conn_id=duplicate1',
+             '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+
         with mock.patch('sys.stdout',
                         new_callable=six.StringIO) as mock_stdout:
             cli.connections(self.parser.parse_args(['connections', '--list']))
@@ -1188,33 +1218,13 @@ class CliTests(unittest.TestCase):
 
         # Assert that some of the connections are present in the output as
         # expected:
-        self.assertIn(['aws_default', 'aws'], conns)
-        self.assertIn(['beeline_default', 'beeline'], conns)
-        self.assertIn(['emr_default', 'emr'], conns)
-        self.assertIn(['mssql_default', 'mssql'], conns)
-        self.assertIn(['mysql_default', 'mysql'], conns)
-        self.assertIn(['postgres_default', 'postgres'], conns)
-        self.assertIn(['wasb_default', 'wasb'], conns)
-        self.assertIn(['segment_default', 'segment'], conns)
-
-        # Attempt to list connections with invalid cli args
-        with mock.patch('sys.stdout',
-                        new_callable=six.StringIO) as mock_stdout:
-            cli.connections(self.parser.parse_args(
-                ['connections', '--list', '--conn_id=fake', '--conn_uri=fake-uri',
-                 '--conn_type=fake-type', '--conn_host=fake_host',
-                 '--conn_login=fake_login', '--conn_password=fake_password',
-                 '--conn_schema=fake_schema', '--conn_port=fake_port', '--conn_extra=fake_extra']))
-            stdout = mock_stdout.getvalue()
-
-        # Check list attempt stdout
-        lines = [l for l in stdout.split('\n') if len(l) > 0]
-        self.assertListEqual(lines, [
-            ("\tThe following args are not compatible with the " +
-             "--list flag: ['conn_id', 'conn_uri', 'conn_extra', " +
-             "'conn_type', 'conn_host', 'conn_login', " +
-             "'conn_password', 'conn_schema', 'conn_port']"),
-        ])
+        self.assertIn(['new1', 'postgres'], conns)
+        self.assertIn(['new2', 'postgres'], conns)
+        self.assertIn(['new3', 'postgres'], conns)
+        self.assertIn(['new4', 'postgres'], conns)
+        self.assertIn(['new5', 'hive_metastore'], conns)
+        self.assertIn(['new6', 'google_cloud_platform'], conns)
+        self.assertIn(['duplicate1', 'postgres'], conns)
 
     def test_cli_connections_list_redirect(self):
         cmd = ['airflow', 'connections', '--list']
@@ -1223,7 +1233,7 @@ class CliTests(unittest.TestCase):
             p.wait()
             self.assertEqual(0, p.returncode)
 
-    def test_cli_connections_add_delete(self):
+    def test_cli_connections(self):
         # Add connections:
         uri = 'postgresql://airflow:airflow@host:5432/airflow'
         with mock.patch('sys.stdout',
@@ -1248,37 +1258,26 @@ class CliTests(unittest.TestCase):
             cli.connections(self.parser.parse_args(
                 ['connections', '-a', '--conn_id=new6',
                  '--conn_uri', "", '--conn_type=google_cloud_platform', '--conn_extra', "{'extra': 'yes'}"]))
+            cli.connections(self.parser.parse_args(
+                ['connections', '--add', '--conn_id=duplicate1',
+                 '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
+            cli.connections(self.parser.parse_args(
+                ['connections', '-a', '--conn_id=duplicate1',
+                 '--conn_uri=%s' % uri, '--conn_extra', "{'extra': 'yes'}"]))
             stdout = mock_stdout.getvalue()
 
         # Check addition stdout
         lines = [l for l in stdout.split('\n') if len(l) > 0]
-        self.assertListEqual(lines, [
-            ("\tSuccessfully added `conn_id`=new1 : " +
-             "postgresql://airflow:airflow@host:5432/airflow"),
-            ("\tSuccessfully added `conn_id`=new2 : " +
-             "postgresql://airflow:airflow@host:5432/airflow"),
-            ("\tSuccessfully added `conn_id`=new3 : " +
-             "postgresql://airflow:airflow@host:5432/airflow"),
-            ("\tSuccessfully added `conn_id`=new4 : " +
-             "postgresql://airflow:airflow@host:5432/airflow"),
-            ("\tSuccessfully added `conn_id`=new5 : " +
-             "hive_metastore://airflow:airflow@host:9083/airflow"),
-            ("\tSuccessfully added `conn_id`=new6 : " +
-             "google_cloud_platform://:@:")
-        ])
 
-        # Attempt to add duplicate
-        with mock.patch('sys.stdout',
-                        new_callable=six.StringIO) as mock_stdout:
-            cli.connections(self.parser.parse_args(
-                ['connections', '--add', '--conn_id=new1',
-                 '--conn_uri=%s' % uri]))
-            stdout = mock_stdout.getvalue()
-
-        # Check stdout for addition attempt
-        lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            "\tA connection with `conn_id`=new1 already exists",
+            "Successfully added `conn_id`=new1 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=new2 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=new3 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=new4 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=new5 : hive_metastore://airflow:airflow@host:9083/airflow",
+            "Successfully added `conn_id`=new6 : google_cloud_platform://:@:",
+            "Successfully added `conn_id`=duplicate1 : postgres://airflow:airflow@host:5432/airflow",
+            "Successfully added `conn_id`=duplicate1 : postgres://airflow:airflow@host:5432/airflow",
         ])
 
         # Attempt to add without providing conn_id
@@ -1291,7 +1290,7 @@ class CliTests(unittest.TestCase):
         # Check stdout for addition attempt
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            ("\tThe following args are required to add a connection:" +
+            ("The following args are required to add a connection:" +
              " ['conn_id']"),
         ])
 
@@ -1305,18 +1304,17 @@ class CliTests(unittest.TestCase):
         # Check stdout for addition attempt
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            ("\tThe following args are required to add a connection:" +
+            ("The following args are required to add a connection:" +
              " ['conn_uri or conn_type']"),
         ])
 
-        # Prepare to add connections
+        # validate adding connections reached the DB
         session = settings.Session()
         extra = {'new1': None,
                  'new2': None,
                  'new3': "{'extra': 'yes'}",
-                 'new4': "{'extra': 'yes'}"}
+                 'new4': "{'extra': 'yes'}", }
 
-        # Add connections
         for index in range(1, 6):
             conn_id = 'new%s' % index
             result = (session
@@ -1331,6 +1329,109 @@ class CliTests(unittest.TestCase):
             elif conn_id == 'new5':
                 self.assertEqual(result, (conn_id, 'hive_metastore', 'host',
                                           9083, None))
+            elif conn_id == 'new6':
+                self.assertEqual(result, (conn_id, 'google_cloud_platform',
+                                          None, None, "{'extra': 'yes'}"))
+
+        # validate duplicate connections made it to the db
+        dup_conns = (session
+                     .query(Connection)
+                     .filter(Connection.conn_id == 'duplicate1')).all()
+        self.assertEqual(2, len(dup_conns))
+        for conn in dup_conns:
+            result = (conn.conn_id, conn.conn_type, conn.host,
+                      conn.port, conn.get_extra())
+            self.assertEqual(result, ('duplicate1', 'postgres', 'host', 5432,
+                                      "{'extra': 'yes'}"))
+
+        # Update Connections
+        new_uri = 'postgresql://airflow:different_password@host:1234/airflow'
+
+        with mock.patch('sys.stdout',
+                        new_callable=six.StringIO) as mock_stdout:
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=new1',
+                 '--conn_uri=%s' % new_uri]))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '-u', '--conn_id=new2',
+                 '--conn_uri=%s' % new_uri]))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=new3',
+                 '--conn_uri=%s' % new_uri, '--conn_extra', "{'extra': 'yes'}"]))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '-u', '--conn_id=new4',
+                 '--conn_uri=%s' % new_uri, '--conn_extra', "{'extra': 'yes'}"]))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=new5',
+                 '--conn_type=hive_metastore', '--conn_login=airflow',
+                 '--conn_password=different_password', '--conn_host=host',
+                 '--conn_port=1234', '--conn_schema=airflow']))
+
+            cli.connections(self.parser.parse_args(
+                ['connections', '-u', '--conn_id=new6',
+                 '--conn_uri', "", '--conn_type=google_cloud_platform',
+                 '--conn_extra', "{'extra': 'yes'}"]))
+
+            # attempt to update a duplicate connection
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=duplicate1',
+                 '--conn_uri=%s' % new_uri, '--conn_extra', "{'extra': 'yes'}"]))
+
+            stdout = mock_stdout.getvalue()
+
+        # Check update stdout
+        lines = [l for l in stdout.split('\n') if len(l) > 0]
+        self.assertListEqual(lines, [
+            "Successfully updated `conn_id`=new1 : postgres://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new2 : postgres://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new3 : postgres://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new4 : postgres://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new5 : "
+            "hive_metastore://airflow:different_password@host:1234/airflow",
+            "Successfully updated `conn_id`=new6 : google_cloud_platform://:@:",
+            "Updating multiple connections is not supported, "
+            "Found multiple connections with `conn_id`=duplicate1"
+        ])
+
+        # Attempt to udpate without providing conn_uri
+        with mock.patch('sys.stdout',
+                        new_callable=six.StringIO) as mock_stdout:
+            cli.connections(self.parser.parse_args(
+                ['connections', '--update', '--conn_id=new']))
+            stdout = mock_stdout.getvalue()
+
+        # Check stdout
+        lines = [l for l in stdout.split('\n') if len(l) > 0]
+        self.assertListEqual(lines, [
+            ("The following args are required to update a connection:" +
+             " ['conn_uri or conn_type']"),
+        ])
+
+        # validate updates reached the DB
+        session = settings.Session()
+        extra = {'new1': None,
+                 'new2': None,
+                 'new3': "{'extra': 'yes'}",
+                 'new4': "{'extra': 'yes'}", }
+
+        for index in range(1, 6):
+            conn_id = 'new%s' % index
+            result = (session
+                      .query(Connection)
+                      .filter(Connection.conn_id == conn_id)
+                      .first())
+            result = (result.conn_id, result.conn_type, result.host,
+                      result.port, result.get_extra())
+            if conn_id in ['new1', 'new2', 'new3', 'new4']:
+                self.assertEqual(result, (conn_id, 'postgres', 'host', 1234,
+                                          extra[conn_id]))
+            elif conn_id == 'new5':
+                self.assertEqual(result, (conn_id, 'hive_metastore', 'host',
+                                          1234, None))
             elif conn_id == 'new6':
                 self.assertEqual(result, (conn_id, 'google_cloud_platform',
                                           None, None, "{'extra': 'yes'}"))
@@ -1355,12 +1456,12 @@ class CliTests(unittest.TestCase):
         # Check deletion stdout
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            "\tSuccessfully deleted `conn_id`=new1",
-            "\tSuccessfully deleted `conn_id`=new2",
-            "\tSuccessfully deleted `conn_id`=new3",
-            "\tSuccessfully deleted `conn_id`=new4",
-            "\tSuccessfully deleted `conn_id`=new5",
-            "\tSuccessfully deleted `conn_id`=new6"
+            "Successfully deleted `conn_id`=new1",
+            "Successfully deleted `conn_id`=new2",
+            "Successfully deleted `conn_id`=new3",
+            "Successfully deleted `conn_id`=new4",
+            "Successfully deleted `conn_id`=new5",
+            "Successfully deleted `conn_id`=new6"
         ])
 
         # Check deletions
@@ -1382,22 +1483,21 @@ class CliTests(unittest.TestCase):
         # Check deletion attempt stdout
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            "\tDid not find a connection with `conn_id`=fake",
+            "Did not find a connection with `conn_id`=fake",
         ])
 
         # Attempt to delete with invalid cli args
         with mock.patch('sys.stdout',
                         new_callable=six.StringIO) as mock_stdout:
             cli.connections(self.parser.parse_args(
-                ['connections', '--delete', '--conn_id=fake',
+                ['connections', '--delete',
                  '--conn_uri=%s' % uri, '--conn_type=fake-type']))
             stdout = mock_stdout.getvalue()
 
         # Check deletion attempt stdout
         lines = [l for l in stdout.split('\n') if len(l) > 0]
         self.assertListEqual(lines, [
-            ("\tThe following args are not compatible with the " +
-             "--delete flag: ['conn_uri', 'conn_type']"),
+            'To delete a connection, you must provide a value for the --conn_id flag.',
         ])
 
         session.close()


### PR DESCRIPTION
Add update connection method.\nExpose all connections api through REST and cli interface.\nAddress AIRFLOW-2784 preventing connections with\nsame id and different types.

Make sure you have checked _all_ steps below.

### Jira

- [ ] My PR addresses the following [Airflow Jira](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
  - https://issues.apache.org/jira/browse/AIRFLOW-XXX
  - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a Jira issue.

### Description

- [ ] Here are some details about my PR, including screenshots of any UI changes:

### Tests

- [ ] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:

### Commits

- [ ] My commits all reference Jira issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
  1. Subject is separated from body by a blank line
  1. Subject is limited to 50 characters (not including Jira issue reference)
  1. Subject does not end with a period
  1. Subject uses the imperative mood ("add", not "adding")
  1. Body wraps at 72 characters
  1. Body explains "what" and "why", not "how"

### Documentation

- [ ] In case of new functionality, my PR adds documentation that describes how to use it.
  - When adding new operators/hooks/sensors, the autoclass documentation generation needs to be added.

### Code Quality

- [ ] Passes `flake8`
